### PR TITLE
Remove deprecated members from upsert account, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,10 +118,7 @@ properties["array_of_values"] = ["value1", "value2"]
 properties["key_with_empty_value"] = ""
 properties["this_property_will_be_deleted"] = None
 
-member1 = UserIdentified.by_user_id("memberId1")
-member2 = UserIdentified.by_user_id("memberId2")
-
-result = client.upsert_account(account, properties, [member1, member2])
+result = client.upsert_account(account, properties)
 if isinstance(result, Success):
     print(result.request_id)  # str
     print(result.calls_remaining)  # int

--- a/journyio/client.py
+++ b/journyio/client.py
@@ -153,13 +153,12 @@ class Client(object):
         except Exception:
             raise JournyException(f"An unknown error has occurred")
 
-    def upsert_account(self, account: AccountIdentified, properties: Properties, members: List[UserIdentified]) -> \
+    def upsert_account(self, account: AccountIdentified, properties: Properties or None) -> \
         Success[
             None] or Failure:
         assert_journy(isinstance(account, AccountIdentified), "Account is not an AccountIdentified object.")
-        assert_journy(isinstance(properties, Properties), "Properties is not a Properties object.")
-        for member in members:
-            assert_journy(isinstance(member, UserIdentified), f"Member {member} is not a UserIdentified object.")
+        if properties is not None:
+            assert_journy(isinstance(properties, Properties), "Properties is not a Properties object.")
 
         try:
             request = HttpRequest(self.__create_url("/accounts/upsert"), Method.POST,
@@ -167,8 +166,6 @@ class Client(object):
                                   json.dumps({
                                       "identification": account.format_identification(),
                                       "properties": properties.properties,
-                                      "members": [{"identification": member.format_identification()} for member in
-                                                  members]
                                   }))
             response = self.httpclient.send(request)
             calls_remaining = Client.__parse_calls_remaining(response)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -159,7 +159,7 @@ def test_client_upsert_account():
     member1 = UserIdentified.by_user_id("hansId")
     member2 = UserIdentified.by_user_id("manuId")
 
-    response = client.upsert_account(account, properties, [member1, member2])
+    response = client.upsert_account(account, properties)
 
     assert (isinstance(response, Success))
     assert (response.__str__() == "Success(requestId, 4999, None)")
@@ -168,7 +168,7 @@ def test_client_upsert_account():
     assert (response.data is None)
 
     assert (
-        http_client_testing.received_request.__str__() == 'HttpRequest(https://api.journy.io/accounts/upsert, Method.POST, {"content-type": "application/json", "x-api-key": "api-key"}, {"identification": {"domain": "www.journy.io", "accountId": "account_id"}, "properties": {"havedog": false, "name": "Journy"}, "members": [{"identification": {"userId": "hansId"}}, {"identification": {"userId": "manuId"}}]})')
+        http_client_testing.received_request.__str__() == 'HttpRequest(https://api.journy.io/accounts/upsert, Method.POST, {"content-type": "application/json", "x-api-key": "api-key"}, {"identification": {"domain": "www.journy.io", "accountId": "account_id"}, "properties": {"havedog": false, "name": "Journy"}})')
 
 def test_client_add_users_to_account():
     http_client_testing = HttpClientTesting(created_response)


### PR DESCRIPTION
In the future, the `members` argument will not longer be supported by the API. Therefore the SDK's should be updated accordingly. Please consider using `addUsersToAccount` and `removeUsersFromAccount`.